### PR TITLE
Correct testnet message start

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -379,10 +379,10 @@ int main(int argc, char **argv) {
   bool fDNS = true;
   if (opts.fUseTestNet) {
       printf("Using testnet.\n");
-      pchMessageStart[0] = 0xc0;
-      pchMessageStart[1] = 0xc0;
-      pchMessageStart[2] = 0xc0;
-      pchMessageStart[3] = 0xc0;
+      pchMessageStart[0] = 0xfc;
+      pchMessageStart[1] = 0xc1;
+      pchMessageStart[2] = 0xb7;
+      pchMessageStart[3] = 0xdc;
       seeds = testnet_seeds;
       fTestNet = true;
   }

--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 70002;
+static const int PROTOCOL_VERSION = 70003;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB


### PR DESCRIPTION
Also bump protocol version to match minimum for 1.10
