### PR TITLE
Bump protocol version

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 70003;
+static const int PROTOCOL_VERSION = 70012;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB


### PR DESCRIPTION
Bump protocol version to last before alerts were removed, for compatibility with 1.14